### PR TITLE
Fix: Return complete wallet data from creation endpoint

### DIFF
--- a/src/api/handlers/user_handler.rs
+++ b/src/api/handlers/user_handler.rs
@@ -55,11 +55,14 @@ pub async fn create_wallet(
     let login = path.into_inner();
     
     let user_service = UserService::new(pool.get_ref().clone());
-    let wallet_id = user_service.add_wallet(&login, wallet.into_inner()).await?;
+    let created_wallet = user_service.add_wallet(&login, wallet.into_inner()).await?;
+    
+    // Build location header using the wallet ID
+    let location = format!("/resources/users/{}/wallets/{}", login, created_wallet.id.unwrap_or(0));
     
     Ok(HttpResponse::Created()
-        .append_header(("Location", ""))
-        .json(wallet_id))
+        .append_header(("Location", location))
+        .json(created_wallet))
 }
 
 // Handler for GET /resources/users/{login}/wallets/{id}/summary

--- a/src/services/user_service.rs
+++ b/src/services/user_service.rs
@@ -20,7 +20,7 @@ pub trait UserServiceTrait: Send + Sync {
     where
         T: serde::Serialize + std::fmt::Debug + Send + Sync + 'static;
     async fn get_wallets(&self, login: &str) -> Result<Vec<WalletDto>, AppError>;
-    async fn add_wallet(&self, login: &str, wallet: WalletDto) -> Result<i32, AppError>;
+    async fn add_wallet(&self, login: &str, wallet: WalletDto) -> Result<WalletDto, AppError>;
     async fn get_summary(&self, login: &str, wallet_id: i32, date_range: DateRange) -> Result<Summary, AppError>;
     async fn get_expenses(
         &self,
@@ -165,7 +165,7 @@ impl UserServiceTrait for UserService {
     // Additional method implementations would follow the same pattern
     // For brevity, I'm showing just a few of the key methods
     
-    async fn add_wallet(&self, login: &str, wallet_dto: WalletDto) -> Result<i32, AppError> {
+    async fn add_wallet(&self, login: &str, wallet_dto: WalletDto) -> Result<WalletDto, AppError> {
         // This would be implemented as a transaction to ensure data consistency
         let mut tx = self.pool.begin().await
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
@@ -195,7 +195,12 @@ impl UserServiceTrait for UserService {
         tx.commit().await
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         
-        Ok(wallet_id)
+        // Return the complete wallet data
+        Ok(WalletDto {
+            id: Some(wallet_id),
+            name: wallet_dto.name,
+            amount: wallet_dto.amount,
+        })
     }
 
     async fn get_summary(&self, login: &str, wallet_id: i32, _date_range: DateRange) -> Result<Summary, AppError> {
@@ -474,7 +479,7 @@ mod tests {
             where
                 T: serde::Serialize + std::fmt::Debug + Send + Sync + 'static;
             async fn get_wallets(&self, login: &str) -> Result<Vec<WalletDto>, AppError>;
-            async fn add_wallet(&self, login: &str, wallet: WalletDto) -> Result<i32, AppError>;
+            async fn add_wallet(&self, login: &str, wallet: WalletDto) -> Result<WalletDto, AppError>;
             async fn get_summary(&self, login: &str, wallet_id: i32, date_range: DateRange) -> Result<Summary, AppError>;
             async fn get_expenses(&self, login: &str, wallet_id: i32, date_range: DateRange) -> Result<Vec<Expense>, AppError>;
             async fn get_highest_expense(&self, login: &str, wallet_id: i32, date_range: DateRange) -> Result<Option<Expense>, AppError>;

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -130,8 +130,12 @@ impl UserServiceTrait for MockUserService {
         }
     }
     
-    async fn add_wallet(&self, _login: &str, _wallet: WalletDto) -> Result<i32, AppError> {
-        Ok(3)
+    async fn add_wallet(&self, _login: &str, wallet: WalletDto) -> Result<WalletDto, AppError> {
+        Ok(WalletDto {
+            id: Some(3),
+            name: wallet.name,
+            amount: wallet.amount,
+        })
     }
     
     async fn get_summary(&self, _login: &str, _wallet_id: i32, _date_range: DateRange) -> Result<Summary, AppError> {
@@ -396,8 +400,8 @@ async fn test_create_wallet_handler() {
             .route("/resources/users/{login}/wallets", web::post().to(|path: web::Path<String>, wallet: web::Json<WalletDto>| async move {
                 let _login = path.into_inner();
                 let mock = MockUserService;
-                let wallet_id = mock.add_wallet("testuser", wallet.into_inner()).await.unwrap();
-                actix_web::HttpResponse::Created().json(wallet_id)
+                let created_wallet = mock.add_wallet("testuser", wallet.into_inner()).await.unwrap();
+                actix_web::HttpResponse::Created().json(created_wallet)
             }))
             .app_data(web::Data::new(mock_service))
     )
@@ -417,8 +421,10 @@ async fn test_create_wallet_handler() {
     
     assert_eq!(resp.status(), 201);
     let body = test::read_body(resp).await;
-    let wallet_id: i32 = serde_json::from_slice(&body).unwrap();
-    assert_eq!(wallet_id, 3);
+    let created_wallet: WalletDto = serde_json::from_slice(&body).unwrap();
+    assert_eq!(created_wallet.id, Some(3));
+    assert_eq!(created_wallet.name, "New Wallet");
+    assert_eq!(created_wallet.amount.amount, BigDecimal::from(100));
 }
 
 #[actix_rt::test]


### PR DESCRIPTION
## Description
This PR fixes the wallet creation endpoint to return complete wallet data instead of just the wallet ID.

## Changes Made
- **Service Layer**: Updated `UserServiceTrait::add_wallet` return type from `Result<i32, AppError>` to `Result<WalletDto, AppError>`
- **Implementation**: Modified `UserService::add_wallet` to construct and return the complete `WalletDto` with all fields (id, name, amount)
- **Handler**: Updated `create_wallet` handler to return the full wallet object in JSON response
- **Location Header**: Fixed the Location header to properly include the wallet resource path
- **Tests**: Enhanced test assertions to verify all wallet fields are returned correctly

## API Response Example
**Before:**
```json
{
  "id": 3
}
```

**After:**
```json
{
  "id": 3,
  "name": "My Wallet",
  "amount": {
    "amount": "1000.00",
    "currency": "USD"
  }
}
```

## Testing
- ✅ All existing tests pass
- ✅ Updated test `test_create_wallet_handler` now verifies complete wallet data
- ✅ Mock implementations updated to match new signature
- ✅ Build successful with no errors

## Benefits
- Better developer experience - no additional GET request needed
- Follows REST best practices for resource creation
- Consistent with other endpoints like user registration
- Improves API usability and reduces network roundtrips

## Rust Best Practices Applied
Following Rust edition 2024 best practices:
- Return owned values instead of borrowing where appropriate
- Explicit, type-safe return values
- Proper transaction handling maintained
- Clear error propagation

Closes #6