### PR TITLE
feat(wallet): implement DELETE endpoint for wallet removal

### DIFF
--- a/src/api/handlers/user_handler.rs
+++ b/src/api/handlers/user_handler.rs
@@ -111,6 +111,19 @@ pub async fn update_wallet(
     Ok(HttpResponse::Ok().json(updated_wallet))
 }
 
+// Handler for DELETE /resources/users/{login}/wallets/{id}
+pub async fn delete_wallet(
+    pool: web::Data<PgPool>,
+    path: web::Path<(String, i32)>,
+) -> Result<impl Responder, AppError> {
+    let (login, wallet_id) = path.into_inner();
+    
+    let user_service = UserService::new(pool.get_ref().clone());
+    user_service.delete_wallet(&login, wallet_id).await?;
+    
+    Ok(HttpResponse::NoContent().finish())
+}
+
 // Handler for GET /resources/users/{login}/wallets/{id}/summary
 pub async fn get_summary(
     pool: web::Data<PgPool>,

--- a/src/api/routes/user_routes.rs
+++ b/src/api/routes/user_routes.rs
@@ -14,6 +14,7 @@ pub fn user_routes(cfg: &mut web::ServiceConfig) {
             .route("/{login}/wallets", web::get().to(user_handler::get_wallets))
             .route("/{login}/wallets", web::post().to(user_handler::create_wallet))
             .route("/{login}/wallets/{id}", web::put().to(user_handler::update_wallet))
+            .route("/{login}/wallets/{id}", web::delete().to(user_handler::delete_wallet))
             .route("/{login}/wallets/{id}/summary", web::get().to(user_handler::get_summary))
             
             // Expense endpoints

--- a/src/services/user_service.rs
+++ b/src/services/user_service.rs
@@ -23,6 +23,7 @@ pub trait UserServiceTrait: Send + Sync {
     async fn get_wallets(&self, login: &str) -> Result<Vec<WalletDto>, AppError>;
     async fn add_wallet(&self, login: &str, wallet: WalletDto) -> Result<WalletDto, AppError>;
     async fn update_wallet(&self, login: &str, wallet_id: i32, update_data: UpdateWalletDto) -> Result<WalletDto, AppError>;
+    async fn delete_wallet(&self, login: &str, wallet_id: i32) -> Result<(), AppError>;
     async fn get_summary(&self, login: &str, wallet_id: i32, date_range: DateRange) -> Result<Summary, AppError>;
     async fn get_expenses(
         &self,
@@ -311,6 +312,89 @@ impl UserServiceTrait for UserService {
             name: new_name.clone(),
             amount: new_amount.clone(),
         })
+    }
+
+    async fn delete_wallet(&self, login: &str, wallet_id: i32) -> Result<(), AppError> {
+        // First check if the user exists
+        self.check_user_exists(login).await?;
+
+        // Check if the wallet exists and belongs to the user
+        let wallet_belongs_to_user = sqlx::query(
+            "SELECT 1 FROM account_wallet 
+            WHERE account_login = $1 AND wallet_id = $2"
+        )
+        .bind(login)
+        .bind(wallet_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+        if wallet_belongs_to_user.is_none() {
+            // Check if wallet exists at all to provide appropriate error
+            let wallet_exists = sqlx::query(
+                "SELECT 1 FROM wallet WHERE id = $1"
+            )
+            .bind(wallet_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+            if wallet_exists.is_some() {
+                // Wallet exists but doesn't belong to this user
+                return Err(AppError::AuthorizationError(
+                    "Not authorized to delete this wallet".to_string()
+                ));
+            } else {
+                // Wallet doesn't exist
+                return Err(AppError::NotFoundError(
+                    format!("Wallet with id {} not found", wallet_id)
+                ));
+            }
+        }
+
+        // Start a transaction to ensure data consistency
+        let mut tx = self.pool.begin().await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+        // Delete all expenses associated with the wallet first
+        sqlx::query(
+            "DELETE FROM expense WHERE wallet_id = $1"
+        )
+        .bind(wallet_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+        // Delete the account_wallet association
+        sqlx::query(
+            "DELETE FROM account_wallet WHERE wallet_id = $1"
+        )
+        .bind(wallet_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+        // Delete the wallet itself
+        let result = sqlx::query(
+            "DELETE FROM wallet WHERE id = $1"
+        )
+        .bind(wallet_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+        // Verify deletion was successful
+        if result.rows_affected() == 0 {
+            return Err(AppError::DatabaseError(
+                "Failed to delete wallet".to_string()
+            ));
+        }
+
+        // Commit the transaction
+        tx.commit().await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+        Ok(())
     }
 
     async fn get_summary(&self, login: &str, wallet_id: i32, _date_range: DateRange) -> Result<Summary, AppError> {
@@ -651,6 +735,7 @@ mod tests {
             async fn get_wallets(&self, login: &str) -> Result<Vec<WalletDto>, AppError>;
             async fn add_wallet(&self, login: &str, wallet: WalletDto) -> Result<WalletDto, AppError>;
             async fn update_wallet(&self, login: &str, wallet_id: i32, update_data: UpdateWalletDto) -> Result<WalletDto, AppError>;
+            async fn delete_wallet(&self, login: &str, wallet_id: i32) -> Result<(), AppError>;
             async fn get_summary(&self, login: &str, wallet_id: i32, date_range: DateRange) -> Result<Summary, AppError>;
             async fn get_expenses(&self, login: &str, wallet_id: i32, date_range: DateRange) -> Result<Vec<Expense>, AppError>;
             async fn get_highest_expense(&self, login: &str, wallet_id: i32, date_range: DateRange) -> Result<Option<Expense>, AppError>;

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -222,6 +222,30 @@ impl UserServiceTrait for MockUserService {
             amount: new_amount,
         })
     }
+
+    async fn delete_wallet(&self, login: &str, wallet_id: i32) -> Result<(), AppError> {
+        // Simulate user validation
+        if login != "testuser" {
+            return Err(AppError::NotFoundError(format!("User with login '{}' not found", login)));
+        }
+        
+        // Simulate wallet not found (wallet 999 doesn't exist)
+        if wallet_id == 999 {
+            return Err(AppError::NotFoundError(
+                format!("Wallet with id {} not found", wallet_id)
+            ));
+        }
+        
+        // Simulate not authorized (wallet 888 exists but belongs to another user)
+        if wallet_id == 888 {
+            return Err(AppError::AuthorizationError(
+                "Not authorized to delete this wallet".to_string()
+            ));
+        }
+        
+        // Wallets 1 and 2 belong to testuser and can be deleted
+        Ok(())
+    }
     
     async fn get_summary(&self, login: &str, _wallet_id: i32, _date_range: DateRange) -> Result<Summary, AppError> {
         // Simulate user validation
@@ -1587,6 +1611,126 @@ async fn test_delete_user_not_found() {
     
     // Assert - should return 404 Not Found
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// ============================================
+// Delete Wallet Tests
+// ============================================
+
+#[actix_rt::test]
+async fn test_delete_wallet_success() {
+    // Arrange
+    let mock_service = MockUserService;
+    
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(mock_service))
+            .route("/resources/users/{login}/wallets/{id}", web::delete().to(|
+                path: web::Path<(String, i32)>,
+                svc: web::Data<MockUserService>
+            | async move {
+                let (login, wallet_id) = path.into_inner();
+                svc.delete_wallet(&login, wallet_id).await?;
+                Ok::<_, AppError>(HttpResponse::NoContent().finish())
+            }))
+    )
+    .await;
+    
+    // Act - Delete wallet ID 1 for testuser
+    let req = test::TestRequest::delete()
+        .uri("/resources/users/testuser/wallets/1")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    
+    // Assert - should return 204 No Content
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+}
+
+#[actix_rt::test]
+async fn test_delete_wallet_user_not_found() {
+    // Arrange
+    let mock_service = MockUserService;
+    
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(mock_service))
+            .route("/resources/users/{login}/wallets/{id}", web::delete().to(|
+                path: web::Path<(String, i32)>,
+                svc: web::Data<MockUserService>
+            | async move {
+                let (login, wallet_id) = path.into_inner();
+                svc.delete_wallet(&login, wallet_id).await?;
+                Ok::<_, AppError>(HttpResponse::NoContent().finish())
+            }))
+    )
+    .await;
+    
+    // Act - Try to delete wallet for non-existent user
+    let req = test::TestRequest::delete()
+        .uri("/resources/users/nonexistentuser/wallets/1")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    
+    // Assert - should return 404 Not Found
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[actix_rt::test]
+async fn test_delete_wallet_wallet_not_found() {
+    // Arrange
+    let mock_service = MockUserService;
+    
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(mock_service))
+            .route("/resources/users/{login}/wallets/{id}", web::delete().to(|
+                path: web::Path<(String, i32)>,
+                svc: web::Data<MockUserService>
+            | async move {
+                let (login, wallet_id) = path.into_inner();
+                svc.delete_wallet(&login, wallet_id).await?;
+                Ok::<_, AppError>(HttpResponse::NoContent().finish())
+            }))
+    )
+    .await;
+    
+    // Act - Try to delete non-existent wallet (ID 999)
+    let req = test::TestRequest::delete()
+        .uri("/resources/users/testuser/wallets/999")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    
+    // Assert - should return 404 Not Found
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[actix_rt::test]
+async fn test_delete_wallet_not_authorized() {
+    // Arrange
+    let mock_service = MockUserService;
+    
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(mock_service))
+            .route("/resources/users/{login}/wallets/{id}", web::delete().to(|
+                path: web::Path<(String, i32)>,
+                svc: web::Data<MockUserService>
+            | async move {
+                let (login, wallet_id) = path.into_inner();
+                svc.delete_wallet(&login, wallet_id).await?;
+                Ok::<_, AppError>(HttpResponse::NoContent().finish())
+            }))
+    )
+    .await;
+    
+    // Act - Try to delete wallet that belongs to another user (ID 888)
+    let req = test::TestRequest::delete()
+        .uri("/resources/users/testuser/wallets/888")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    
+    // Assert - should return 403 Forbidden
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
 

--- a/tests/postman_collection.json
+++ b/tests/postman_collection.json
@@ -2882,6 +2882,273 @@
             "description": "Attempt to update wallet without authentication - should return 401 Unauthorized"
           },
           "response": []
+        },
+        {
+          "name": "Delete Wallet - Success",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "delete-wallet-success-001",
+                "exec": [
+                  "// ============================================",
+                  "// Delete Wallet - Success (204 No Content)",
+                  "// ============================================",
+                  "",
+                  "pm.test('Status code is 204 No Content', function () {",
+                  "    pm.response.to.have.status(204);",
+                  "});",
+                  "",
+                  "pm.test('Response body is empty', function () {",
+                  "    pm.expect(pm.response.text()).to.be.empty;",
+                  "});",
+                  "",
+                  "// Clean up the wallet ID variable",
+                  "pm.collectionVariables.unset('created_wallet_id');"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "id": "delete-wallet-success-001",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/resources/users/{{test_user_login}}/wallets/{{created_wallet_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "resources",
+                "users",
+                "{{test_user_login}}",
+                "wallets",
+                "{{created_wallet_id}}"
+              ]
+            },
+            "description": "Delete an existing wallet - should return 204 No Content"
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Wallet - Not Found (Error)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "delete-wallet-notfound-001",
+                "exec": [
+                  "// ============================================",
+                  "// Delete Wallet - Not Found (404 Error)",
+                  "// ============================================",
+                  "",
+                  "pm.test('Status code is 404 Not Found', function () {",
+                  "    pm.response.to.have.status(404);",
+                  "});",
+                  "",
+                  "pm.test('Error response has correct structure', function () {",
+                  "    const jsonData = pm.response.json();",
+                  "    pm.expect(jsonData).to.have.property('message');",
+                  "});",
+                  "",
+                  "pm.test('Error message indicates wallet not found', function () {",
+                  "    const jsonData = pm.response.json();",
+                  "    const message = jsonData.message.toLowerCase();",
+                  "    pm.expect(message).to.satisfy(function(msg) {",
+                  "        return msg.includes('not found') || msg.includes('wallet');",
+                  "    });",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "id": "delete-wallet-notfound-001",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/resources/users/{{test_user_login}}/wallets/99999",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "resources",
+                "users",
+                "{{test_user_login}}",
+                "wallets",
+                "99999"
+              ]
+            },
+            "description": "Attempt to delete non-existent wallet - should return 404 Not Found"
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Wallet - User Not Found (Error)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "delete-wallet-user-notfound-001",
+                "exec": [
+                  "// ============================================",
+                  "// Delete Wallet - User Not Found (404 Error)",
+                  "// ============================================",
+                  "",
+                  "pm.test('Status code is 404 Not Found', function () {",
+                  "    pm.response.to.have.status(404);",
+                  "});",
+                  "",
+                  "pm.test('Error response has correct structure', function () {",
+                  "    const jsonData = pm.response.json();",
+                  "    pm.expect(jsonData).to.have.property('message');",
+                  "});",
+                  "",
+                  "pm.test('Error message indicates user not found', function () {",
+                  "    const jsonData = pm.response.json();",
+                  "    const message = jsonData.message.toLowerCase();",
+                  "    pm.expect(message).to.satisfy(function(msg) {",
+                  "        return msg.includes('not found') || msg.includes('user');",
+                  "    });",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "id": "delete-wallet-user-notfound-001",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/resources/users/nonexistent_user/wallets/1",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "resources",
+                "users",
+                "nonexistent_user",
+                "wallets",
+                "1"
+              ]
+            },
+            "description": "Attempt to delete wallet for non-existent user - should return 404 Not Found"
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Wallet - Not Authorized (Error)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "delete-wallet-forbidden-001",
+                "exec": [
+                  "// ============================================",
+                  "// Delete Wallet - Not Authorized (403 Error)",
+                  "// ============================================",
+                  "",
+                  "pm.test('Status code is 403 Forbidden', function () {",
+                  "    pm.response.to.have.status(403);",
+                  "});",
+                  "",
+                  "pm.test('Error response has correct structure', function () {",
+                  "    const jsonData = pm.response.json();",
+                  "    pm.expect(jsonData).to.have.property('message');",
+                  "});",
+                  "",
+                  "pm.test('Error message indicates not authorized', function () {",
+                  "    const jsonData = pm.response.json();",
+                  "    const message = jsonData.message.toLowerCase();",
+                  "    pm.expect(message).to.satisfy(function(msg) {",
+                  "        return msg.includes('authorized') || msg.includes('forbidden') || msg.includes('permission');",
+                  "    });",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "id": "delete-wallet-forbidden-001",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/resources/users/other_user/wallets/1",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "resources",
+                "users",
+                "other_user",
+                "wallets",
+                "1"
+              ]
+            },
+            "description": "Attempt to delete wallet that belongs to another user - should return 403 Forbidden"
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Wallet - Missing Auth (Error)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "delete-wallet-noauth-001",
+                "exec": [
+                  "// ============================================",
+                  "// Delete Wallet - Missing Auth (401 Error)",
+                  "// ============================================",
+                  "",
+                  "pm.test('Status code is 401 Unauthorized', function () {",
+                  "    pm.response.to.have.status(401);",
+                  "});",
+                  "",
+                  "pm.test('Error response has correct structure', function () {",
+                  "    const jsonData = pm.response.json();",
+                  "    pm.expect(jsonData).to.have.property('message');",
+                  "});",
+                  "",
+                  "pm.test('Error message indicates missing authentication', function () {",
+                  "    const jsonData = pm.response.json();",
+                  "    const message = jsonData.message.toLowerCase();",
+                  "    pm.expect(message).to.satisfy(function(msg) {",
+                  "        return msg.includes('authorization') || msg.includes('unauthorized') || msg.includes('missing');",
+                  "    });",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "id": "delete-wallet-noauth-001",
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/resources/users/{{test_user_login}}/wallets/1",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "resources",
+                "users",
+                "{{test_user_login}}",
+                "wallets",
+                "1"
+              ]
+            },
+            "description": "Attempt to delete wallet without authentication - should return 401 Unauthorized"
+          },
+          "response": []
         }
       ],
       "id": "3b62a6f3-79de-4fe1-bda9-c0bcc4da3b22",


### PR DESCRIPTION
## Summary

This PR implements a secure DELETE endpoint for wallet removal in the FinGest Money Manager API.

## Related Issue

Closes #38

## Changes Made

### Service Layer (`src/services/user_service.rs`)
- Added `delete_wallet` method signature to `UserServiceTrait`
- Implemented `delete_wallet` in `UserService` with:
  - User existence validation
  - Wallet ownership verification  
  - Transaction-based deletion for data consistency
  - Cascading deletion of associated expenses

### Handler (`src/api/handlers/user_handler.rs`)
- Added `delete_wallet` handler function

### Routes (`src/api/routes/user_routes.rs`)
- Added DELETE route for `/{login}/wallets/{id}`

### Tests (`tests/api_tests.rs`)
- Added `delete_wallet` method to `MockUserService`
- Added 4 integration tests:
  - `test_delete_wallet_success` - 204 No Content
  - `test_delete_wallet_user_not_found` - 404 Not Found
  - `test_delete_wallet_wallet_not_found` - 404 Not Found
  - `test_delete_wallet_not_authorized` - 403 Forbidden

### Postman Collection (`tests/postman_collection.json`)
- Added 6 test cases for the delete wallet endpoint:
  - Delete Wallet - Success (204)
  - Delete Wallet - Not Found (404)
  - Delete Wallet - User Not Found (404)
  - Delete Wallet - Not Authorized (403)
  - Delete Wallet - Missing Auth (401)

## Authorization Flow

| Condition | HTTP Response |
|-----------|---------------|
| Missing/invalid JWT token | `401 Unauthorized` |
| User doesn't exist | `404 Not Found` |
| Wallet doesn't exist | `404 Not Found` |
| User not authorized | `403 Forbidden` |
| Success | `204 No Content` |

## Testing

- [x] `cargo build` - Compiles successfully
- [x] `cargo test delete_wallet` - All 4 tests pass
- [x] `cargo clippy` - No new warnings

## Checklist

- [x] Code follows existing patterns and conventions
- [x] All tests pass
- [x] Postman collection updated
- [x] Documentation updated (issue created)